### PR TITLE
specify stricter constraint for libc version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,27 +1,27 @@
 [root]
 name = "sass-rs"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "sass-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sass-sys 0.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.1.7"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sass-sys"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ path = "src/lib.rs"
 
 [dependencies]
 sass-sys = "0"
-libc = "0"
+libc = "0.1"


### PR DESCRIPTION
sass-sys specifies a constraint of "0.1", but sass-rs specifies "0",
which allows version 0.2 and above

this shouldn't be a problem, because a "0.1" version would satisfy both
constraints, but I think the reason this isn't working is because of
rust-lang/cargo#2064 which might not get resolved anytime soon

without this fix, building sass-rs fails because it tries to use
libc 0.2 which has a different interface from the 0.1 that sass-sys used

this gets things building again for now, but we should look into
updating to the 0.2 interface when we get a chance

By the way, I don't think we should version Cargo.lock