### PR TITLE
Fix a documentation killing typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv=refresh content=0;url=sass-rs/index.html>
+<meta http-equiv=refresh content=0;url=sass_rs/index.html>


### PR DESCRIPTION
I'm not sure if this is where you need to change it but it fixes the broken redirect.