### PR TITLE
Add API for specifying output style.

### DIFF
--- a/examples/compile_sass.rs
+++ b/examples/compile_sass.rs
@@ -1,7 +1,7 @@
 /// Example file on how to compile a scss file.
 
 extern crate sass_rs;
-use sass_rs::sass_context::SassFileContext;
+use sass_rs::sass_context::{SassFileContext, OutputStyle};
 use sass_rs::sass_function::*;
 use sass_rs::sass_value::*;
 use sass_rs::dispatcher::Dispatcher;
@@ -19,18 +19,20 @@ impl SassFunction for Foo {
 }
 
 /// Setup the environment and compile a file.
-fn compile(filename:&str) {
+fn compile(filename:&str, style:OutputStyle) {
     let mut file_context = SassFileContext::new(filename);
     let foo = Foo;
     let fns:Vec<(&'static str,Box<SassFunction>)> = vec![("foo($x)", Box::new(foo))];
     let options = file_context.sass_context.sass_options.clone();
+    options.write().ok().unwrap().set_output_style(style.clone());
     thread::spawn(move|| {
         let dispatcher = Dispatcher::build(fns,options);
         while dispatcher.dispatch().is_ok() {}
     });
     let out = file_context.compile();
     match out {
-        Ok(css) => println!("------- css  ------\n{}\n--------", css),
+        Ok(css) => println!("------- css ({:?}) ------\n{}--------",
+                            style, css),
         Err(err) => println!("{}", err)
     };
 }
@@ -40,5 +42,6 @@ pub fn main() {
     let _ = args.next();
     let file = args.next().expect("Please pass in a file name");
     println!("Compiling sass file: `{}`.", file);
-    compile(&file);
+    compile(&file, OutputStyle::Expanded);
+    compile(&file, OutputStyle::Compressed);
 }

--- a/src/sass_context.rs
+++ b/src/sass_context.rs
@@ -8,6 +8,13 @@ use ptr::Unique;
 use std::sync::{Arc,RwLock};
 
 
+#[derive(Debug, Clone)]
+pub enum OutputStyle {
+    Nested,
+    Expanded,
+    Compact,
+    Compressed
+}
 
 #[derive(Debug)]
 pub struct SassOptions {
@@ -27,6 +34,18 @@ impl SassOptions {
                 sass_sys::sass_function_set_list_entry(fn_list, i, sass_fn);
             }
             sass_sys::sass_option_set_c_functions(self.raw.get_mut(), fn_list);
+        }
+    }
+
+    pub fn set_output_style(&mut self, style: OutputStyle) {
+        let style = match style {
+            OutputStyle::Nested => sass_sys::SASS_STYLE_NESTED,
+            OutputStyle::Expanded => sass_sys::SASS_STYLE_EXPANDED,
+            OutputStyle::Compact => sass_sys::SASS_STYLE_COMPACT,
+            OutputStyle::Compressed => sass_sys::SASS_STYLE_COMPRESSED,
+        };
+        unsafe {
+            sass_sys::sass_option_set_output_style(self.raw.get_mut(), style);
         }
     }
 }


### PR DESCRIPTION
Without this, raw sass_sys need to be used for specifying output style.

The compile_sass example is changed to output two different styles.