### PR TITLE
Fix linking on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
   matrix:
       - TARGET: x86_64-pc-windows-msvc
         CHANNEL: stable
+      - TARGET: i686-pc-windows-msvc
+        CHANNEL: stable
 
 install:
   # Install Rust and Cargo

--- a/sass-sys/Cargo.toml
+++ b/sass-sys/Cargo.toml
@@ -20,3 +20,5 @@ bindgen = "0.26"
 [dependencies]
 libc = "0.2"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+gcc = "0.3.51"


### PR DESCRIPTION
Fixes linking on Windows by disabling link time code generation, and adds testing target i686-pc-windows-msvc to AppVeyor.