### PR TITLE
Build libsass using multiple parallel jobs

### DIFF
--- a/sass-sys/Cargo.toml
+++ b/sass-sys/Cargo.toml
@@ -18,6 +18,7 @@ homepage = "https://github.com/compass-rs/sass-rs"
 
 [build-dependencies]
 pkg-config = "0.3"
+num_cpus = "1.9.0"
 # bindgen = "0.36"
 
 [dependencies]

--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -2,6 +2,7 @@
 #[cfg(target_env = "msvc")]
 extern crate cc;
 extern crate pkg_config;
+extern crate num_cpus;
 
 use std::env;
 use std::fs;
@@ -70,6 +71,7 @@ fn compile() {
 
     let r = Command::new(if is_bsd { "gmake" } else { "make" })
         .current_dir(&build)
+        .args(&["--jobs", &num_cpus::get().to_string()])
         .output()
         .expect("error running make");
 


### PR DESCRIPTION
This allow to reduce compilation time of the crate from 1m25s to 25s on my machine.

The only downside is that it introduces a build dependency on num_cpus crate.