### PR TITLE
Added binary support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,30 @@
+extern crate sass_rs;
+
+use sass_rs::{compile_string, Options, OutputStyle};
+use std::io::{self, Read};
+
+fn main() {
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer).unwrap();
+
+    let mut opts = Options::default();
+
+    // SCSS vs. SASS.
+    if std::env::args().any(|i| i == "--sass") {
+        opts.indented_syntax = true;
+    }
+
+    // Output style.
+    if std::env::args().any(|i| i == "--expanded") {
+        opts.output_style = OutputStyle::Expanded;
+    }
+    if std::env::args().any(|i| i == "--compact") {
+        opts.output_style = OutputStyle::Compact;
+    }
+    if std::env::args().any(|i| i == "--compressed") {
+        opts.output_style = OutputStyle::Compressed;
+    }
+
+    let sass = compile_string(buffer.as_str(), opts).unwrap();
+    println!("{}", sass);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ fn main() {
         opts.output_style = OutputStyle::Compressed;
     }
 
-    let sass = compile_string(buffer.as_str(), opts).unwrap();
-    println!("{}", sass);
+    match compile_string(buffer.as_str(), opts) {
+        Ok(sass) => println!("{}", sass),
+        Err(e) => {
+            println!("\nSASS/SCSS couldn't be converted bacause of the following error. Please check the input.\n");
+            eprintln!("{}", e);
+        }
+    }
 }


### PR DESCRIPTION
Hi

I've added small `main.rs` which adds binary support. Now the library can be installed with `cargo install` and can be used as command.

The library defaults to SCSS input and to nested output. This can be easily changed by a few params.

```
sass-rs < source/style.scss  # for SCSS
sass-rs --sass < source/style.sass  # for SASS
sass-rs --sass --expanded < source/style.sass
sass-rs --sass --compact < source/style.sass
sass-rs --sass --compressed < source/style.sass
```

Tested as:

```
~/w/site » sass-rs --sass < source/style.sass                                                                                                                                          
.test {
  border: 1px solid black;
  display: inline; }
  .test .test {
    border: 1px solid black;
    display: inline; }
```

My favourite usage is `sass-rs --sass --compressed < source/style.sass > build/style.css`