### PR TITLE
Override --jobs option value with an env var in build.rs

### DIFF
--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -69,9 +69,10 @@ fn compile() {
         || target.contains("netbsd")
         || target.contains("openbsd");
 
+    let jobs = env::var("MAKE_LIBSASS_JOBS").unwrap_or(num_cpus::get().to_string());
     let r = Command::new(if is_bsd { "gmake" } else { "make" })
         .current_dir(&build)
-        .args(&["--jobs", &num_cpus::get().to_string()])
+        .args(&["--jobs", &jobs])
         .output()
         .expect("error running make");
 


### PR DESCRIPTION
This patch enables build.rs to override --jobs option value of
make command with MAKE_LIBSASS_JOBS environment variable.

In typical containerization system (e.g. Docker), the number of CPU cores
which are visible from a process jailed into a container can be greater than
the container limitation.

This change is useful in the above situation. (Of course, not only that!)

---

I am developing a my own static site generator named [Salmon](https://github.com/mozamimy/salmon). That app uses this crate to compile Sass files. This wrapper library is great for me 😃! I appreciate maintainers' contributions.

I am trying automation of release the app, however, sometimes a building job is failed like https://circleci.com/gh/mozamimy/salmon/93 memory allocation error.

CircleCI is using Docker for containerization technology to isolate each build environment. The building process by build.rs finds the number of CPU is 36 with current implementaion. However, the actual given CPU cores are two and the memory limitation is 4096MB.

So I want to inject the parameter of `--jobs` from out of build.rs. 

I guess `MAKE_LIBSASS_JOBS` is good naming and using environment variable is good solution... But I'm not too confident!

