### PR TITLE
Compile on windows vs2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 This crate is a wrapper around [libsass](https://github.com/sass/libsass), currently tracking
-[v3.5.5](https://github.com/sass/libsass/releases/tag/3.5.5).
+[v3.6.1](https://github.com/sass/libsass/releases/tag/3.6.1).
 
 To build this crate on Windows, you will need to have Visual Studio installed.
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ This is a small added feature that isn't meant to fulfill every usecases. If you
 ## Not supported yet
 [Importers](https://github.com/sass/libsass/blob/master/docs/api-importer.md) and
 [functions](https://github.com/sass/libsass/blob/master/docs/api-function.md) are not supported yet.
+
+
+## Building (Windows)
+
+Windows compilation using VS 2019 requires that all the environment variables for MSBuild to be availble.
+
+An indicator that the environment is not properply setup is the following error message:
+
+```
+error MSB4019: The imported project "C:\Microsoft.Cpp.Default.props" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
+```
+
+If you find this error, you have a couple of of options to select:
+
+- [Easiest] Open the `Developer Command Prompt for VS 2019` application to compile the project. This terminal will setup all the needed environment variables to let it compile.
+- Setup the environment variables (eg: `PATH`, `LIB`) as [documented on Microsoft's website](https://docs.microsoft.com/en-us/cpp/build/setting-the-path-and-environment-variables-for-command-line-builds?view=vs-2019)
+- Install the complete setup of Visual Studio 2015 - not only the Visual C++ Build tools

--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -128,8 +128,18 @@ fn compile() {
         }
     }
 
-    let r = cc::windows_registry::find(target.as_str(), "msbuild.exe")
-        .expect("could not find msbuild")
+    let search = Command::new("which")
+        .args(&["msbuild.exe"])
+        .output()
+        .expect("Could not search for msbuild.exe on path");
+    let mut msbuild = if search.status.success() {
+        Command::new("msbuild.exe")
+    } else {
+        cc::windows_registry::find(target.as_str(), "msbuild.exe")
+            .expect("Could not find msbuild.exe on the registry")
+    };
+
+    let r = msbuild
         .args(&[
             "win\\libsass.sln",
             "/p:LIBSASS_STATIC_LIB=1",


### PR DESCRIPTION
This PR has a couple of changes that allowed `sass-sys` to compile on a fresh installation of Windows 10 with VisualStudio Build Tools 2019. This is an attempt to help with #34, but I've only been able to test it on a specific environment to call it fixed.

With this changes, executing on a `Developer Console for VS 2019`, we are able to compile the app and avoid the error reported by @raphlinus on https://github.com/compass-rs/sass-rs/issues/34#issuecomment-492079749.

The error is regarding tooling on Windows, and there might not be much to be fixed by the project compilation steps on itself, but the instructions are a best effort attempt to fix them.

It also bumps the version of `libsass` provided, in order to have the fixes for VSCode 2019 compilation.