### PR TITLE
Remove stray semicolon after opening bracket

### DIFF
--- a/src/bindings/context.rs
+++ b/src/bindings/context.rs
@@ -38,7 +38,7 @@ pub enum Context {
 
 
 impl Context {
-    fn make_sass_context(c_sass_context: *mut sass_sys::Sass_Context) -> SassContext {;
+    fn make_sass_context(c_sass_context: *mut sass_sys::Sass_Context) -> SassContext {
         let options = unsafe { sass_sys::sass_context_get_options(c_sass_context) };
         let sass_options = Arc::new(RwLock::new(SassOptions {
             raw: unsafe { Unique::new(options) }


### PR DESCRIPTION
We have a stray semicolon at the end of a line after an opening
bracket.  This has no effect except to produce a build warning, so
let's remove it.