### PR TITLE
Fix detection of C++ standard library on FreeBSD.

### DIFF
--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -75,7 +75,9 @@ fn get_libsass_folder() -> PathBuf {
 
 #[cfg(not(target_os = "macos"))]
 fn _compile(libprobe: fn(&str) -> bool) {
-    if libprobe("stdc++") {
+    if cfg!(target_os = "freebsd") && libprobe("c++") {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else if libprobe("stdc++") {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     } else if libprobe("c++_shared") {
         println!("cargo:rustc-link-lib=dylib=c++_shared");

--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -73,11 +73,9 @@ fn get_libsass_folder() -> PathBuf {
     env::current_dir().unwrap().join("libsass")
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 fn _compile(libprobe: fn(&str) -> bool) {
-    if cfg!(target_os = "freebsd") && libprobe("c++") {
-        println!("cargo:rustc-link-lib=dylib=c++");
-    } else if libprobe("stdc++") {
+    if libprobe("stdc++") {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     } else if libprobe("c++_shared") {
         println!("cargo:rustc-link-lib=dylib=c++_shared");
@@ -88,9 +86,8 @@ fn _compile(libprobe: fn(&str) -> bool) {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(not(target_os = "linux"))]
 fn _compile(libprobe: fn(&str) -> bool) {
-
     if libprobe("c++_shared") {
         println!("cargo:rustc-link-lib=dylib=c++_shared");
     } else if libprobe("c++") {


### PR DESCRIPTION
Due to the way libprobe is written, this always
detected libstdc++ by accident.

Addresses https://github.com/compass-rs/sass-rs/issues/66