### PR TITLE
fix: add more details to expects and replace unwraps with expects

### DIFF
--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -41,7 +41,7 @@ fn cp_r(dir: &Path, dest: &Path) {
     for entry in t!(fs::read_dir(dir)) {
         let entry = t!(entry);
         let path = entry.path();
-        let dst = dest.join(path.file_name().unwrap());
+        let dst = dest.join(path.file_name().expect("Failed to get filename of path"));
         if t!(fs::metadata(&path)).is_file() {
             t!(fs::copy(path, dst));
         } else {
@@ -58,19 +58,19 @@ fn init_submodule() {
         .arg("init")
         .stderr(Stdio::null())
         .status()
-        .expect("")
+        .expect("Failed to run 'git submodule init'. Do you have git installed?")
         .success();
     Command::new("git")
         .arg("submodule")
         .arg("update")
         .stderr(Stdio::null())
         .status()
-        .expect("")
+        .expect("Failed to run 'git submodule update'. Do you have git installed?")
         .success();
 }
 
 fn get_libsass_folder() -> PathBuf {
-    env::current_dir().unwrap().join("libsass")
+    env::current_dir().expect("Failed to get the current directory").join("libsass")
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -105,7 +105,7 @@ fn _compile(libprobe: fn(&str) -> bool) {
 fn compile() {
     let target = env::var("TARGET").expect("TARGET not found");
     let src = get_libsass_folder();
-    let dest = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let dest = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not found"));
     let build = dest.join("build");
     t!(fs::create_dir_all(&build));
     cp_r(&src, &build);
@@ -113,12 +113,12 @@ fn compile() {
         || target.contains("freebsd")
         || target.contains("netbsd")
         || target.contains("openbsd");
-    let jobs = env::var("MAKE_LIBSASS_JOBS").unwrap_or(num_cpus::get().to_string());
+    let jobs = env::var("MAKE_LIBSASS_JOBS").unwrap_or_else(|_| num_cpus::get().to_string());
     let r = Command::new(if is_bsd { "gmake" } else { "make" })
         .current_dir(&build)
         .args(&["--jobs", &jobs])
         .output()
-        .expect("error running make");
+        .expect("Failed to run make/gmake. Do you have it installed?");
 
     if !r.status.success() {
         let err = String::from_utf8_lossy(&r.stderr);
@@ -140,7 +140,7 @@ fn compile() {
         .arg("-shared")
         .stderr(Stdio::null())
         .status()
-        .expect("")
+        .expect("Failed to run cc. Do you have it installed?")
         .success()
     };
     _compile(libprobe);
@@ -156,7 +156,7 @@ fn compile() {
     } else {
         "Win32"
     };
-    let dest = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let dest = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not found in environment"));
     let build = dest.join("build");
     t!(fs::create_dir_all(&build));
     cp_r(&src, &build);
@@ -169,7 +169,7 @@ fn compile() {
             .args(&["/upgrade", "win\\libsass.sln"])
             .current_dir(&build)
             .output()
-            .expect("error running devenv");
+            .expect("Failed to run devenv. Do you have it installed?");
         if !d.status.success() {
             let err = String::from_utf8_lossy(&d.stderr);
             let out = String::from_utf8_lossy(&d.stdout);
@@ -180,7 +180,7 @@ fn compile() {
     let search = Command::new("where")
         .args(&["msbuild.exe"])
         .output()
-        .expect("Could not search for msbuild.exe on path");
+        .expect("Failed to run where: Could not search for msbuild.exe on path.");
     let mut msbuild = if search.status.success() {
         Command::new("msbuild.exe")
     } else {
@@ -188,7 +188,7 @@ fn compile() {
             .expect("Could not find msbuild.exe on the registry")
     };
 
-    let jobs = env::var("MAKE_LIBSASS_JOBS").unwrap_or(num_cpus::get().to_string());
+    let jobs = env::var("MAKE_LIBSASS_JOBS").unwrap_or_else(|_| num_cpus::get().to_string());
 
     let r = msbuild
         .args(&[
@@ -201,7 +201,7 @@ fn compile() {
         ])
         .current_dir(&build)
         .output()
-        .expect("error running msbuild");
+        .expect("Failed to run msbuild. Do you have it installed?");
 
     if !r.status.success() {
         let err = String::from_utf8_lossy(&r.stderr);


### PR DESCRIPTION
As a fix to the issue #30 the error messages from the build script have been verbosified so that the end user can more understand the problems encountered, especially on a musl target.