### PR TITLE
sass-sys: PKG_CONFIG_ALL_STATIC

### DIFF
--- a/sass-sys/build.rs
+++ b/sass-sys/build.rs
@@ -204,6 +204,18 @@ fn main() {
 
     // Is it already built?
     if pkg_config::find_library("libsass").is_ok() {
+
+        let r = Command::new("cc")
+            .arg("--print-search-dirs")
+            .output()
+            .expect("Failed to run cc. Do you have it installed?");
+        let out = String::from_utf8_lossy(&r.stdout);
+        println!(
+            "cargo:rustc-link-search=native={}",
+            out.split_whitespace().nth(1).unwrap_or(".")
+        );
+        println!("cargo:rustc-link-lib=static=stdc++");
+
         return;
     }
 


### PR DESCRIPTION
Currently if you run `cargo build`, the resultant `sass-rs` executable is a
shared build. For example with Windows:

~~~
PS C:\sass-rs> objdump -p target\debug\sass-rs.exe | Select-String DLL
DLL Name: libsass-1.dll
~~~

To resolve, normally you would just do:

~~~
$env:PKG_CONFIG_ALL_STATIC = 1
~~~

but then you get this:

~~~
= note: sass-rs\target\debug\deps\libsass_sys-172acfe0fd31d51a.rlib
(sass_context.o):(.text+0x3ae): undefined reference to
`std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>
>::_M_create(unsigned long long&, unsigned long long)'
~~~

To resolve, we can declare LibStdC++ static as well, and provide the path to the
static library.